### PR TITLE
Add og metadata via seo plugin. Fixes #9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 ruby File.read(File.join(File.dirname(__FILE__), '.ruby-version')).strip
 
 gem "jekyll"
-
-
+gem "jekyll-seo-tag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,8 @@ GEM
       webrick (~> 1.7)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -76,6 +78,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-seo-tag
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,11 @@
 title: Alliance of Civic Technologists
 description: ACT is a decentralized network of civic tech volunteer organizations.
+
 url: "https://www.civictechnologists.org" # the base hostname & protocol for your site, e.g. http://example.com
 baseurl: "" # the subpath of your site, e.g. /blog
+
 timezone: "America/New_York"
+
 exclude:
   - .sass-cache/
   - .jekyll-cache/
@@ -16,7 +19,12 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - README.md
+
 permalink: "/:year/:month/:title"
+
+plugins:
+  - jekyll-seo-tag
+
 defaults:
   - scope:
       path: ""

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -5,14 +5,13 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
     <link rel="stylesheet" href="{{ "/assets/stylesheets/main.css" | relative_url }}">
     <script src="{{ "/assets/javascripts/main.js" | relative_url }}"></script>
 
     <link rel="icon" href="{{ "/assets/images/icon.png" | relative_url }}">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }} RSS" href="{{ "/feed.xml" | relative_url }}">
+
+    {% seo %}
   </head>
   <body class="page-{{ page.title | slugify }}">
     <!-- Google Analytcs -->

--- a/index.markdown
+++ b/index.markdown
@@ -1,6 +1,7 @@
 ---
 layout: home
 title: Home
+image: /assets/images/logo.png
 ---
 
 <img src="{{ "/assets/images/logo.png" | relative_url }}" alt="" class="img-fluid" />


### PR DESCRIPTION
Adding the jekyll seo plugin. Note that you'll want to add an `image` field in the frontmatter of any page that should have an image associated with it. I only did this on the homepage, because it's not always desirable to have an image when just text will do.