### PR TITLE
Fix broken back to News link on post pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,6 @@ layout: default
 </div>
 
 <section class="page-nav">
-  <a href="/news/" class="page-nav-link">Back to News</a>
+  <a href="{{ "/news" | relative_url }}" class="page-nav-link">Back to News</a>
 </section>
 


### PR DESCRIPTION
The "Back to News" link on post pages pointed to `/news/` with a trailing slash, but the news page builds to `/news.html`, so the link 404'd. This updates it to use `relative_url` with `/news`, matching the working link already used in `nav.html`.