### PR TITLE
Split CityCamp city page events into upcoming and past

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gem "jekyll-seo-tag"
 
 group :test do
   gem "rspec"
+  gem "timecop"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    timecop (0.9.11)
     unicode-display_width (2.6.0)
     webrick (1.9.2)
 
@@ -111,6 +112,7 @@ DEPENDENCIES
   jekyll
   jekyll-seo-tag
   rspec
+  timecop
 
 RUBY VERSION
   ruby 4.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/_layouts/citycamp-city.html
+++ b/_layouts/citycamp-city.html
@@ -13,12 +13,39 @@ layout: base
 <div class="container">
   <p><a href="/citycamp">&larr; All CityCamp cities</a></p>
 
-  {% if page.events.size > 0 %}
+  {% if page.upcoming_events.size > 0 %}
   <header class="page-header mt-4">
-    <h2 class="page-title">Future and past events</h2>
+    <h2 class="page-title">Upcoming events</h2>
   </header>
-  {% assign sorted_events = page.events | sort: "date" | reverse %}
-  {% for event in sorted_events %}
+  {% for event in page.upcoming_events %}
+  <div class="card mb-3">
+    <div class="card-body">
+      <div class="text-danger fw-bold small text-uppercase">{{ event.date | date: "%B %-d, %Y" }}</div>
+      <h5 class="mb-1">{{ event.name }}</h5>
+      {% if event.venue %}
+      <div class="text-muted">{{ event.venue }}{% if event.address %} &mdash; {{ event.address }}{% endif %}</div>
+      {% endif %}
+      {% if event.organizer %}
+      <div class="small text-secondary mt-1">Organized by {% if event.organizer_website %}<a href="{{ event.organizer_website }}" target="_blank" rel="noopener">{{ event.organizer }}</a>{% else %}{{ event.organizer }}{% endif %}</div>
+      {% endif %}
+      {% if event.website %}
+      <div class="mt-2">
+        <a href="{{ event.website }}" class="btn btn-primary btn-sm" target="_blank" rel="noopener">Register &rarr;</a>
+      </div>
+      {% endif %}
+      {% if event.about %}
+      <div class="mt-2">{{ event.about | markdownify }}</div>
+      {% endif %}
+    </div>
+  </div>
+  {% endfor %}
+  {% endif %}
+
+  {% if page.past_events.size > 0 %}
+  <header class="page-header mt-4">
+    <h2 class="page-title">Past events</h2>
+  </header>
+  {% for event in page.past_events %}
   <div class="card mb-3">
     <div class="card-body">
       <div class="text-danger fw-bold small text-uppercase">{{ event.date | date: "%B %-d, %Y" }}</div>

--- a/_plugins/citycamp_latest_event.rb
+++ b/_plugins/citycamp_latest_event.rb
@@ -15,10 +15,13 @@ Jekyll::Hooks.register :site, :pre_render do |site|
 
   past_events = []
   site.collections["citycamp"]&.docs&.each do |doc|
-    (doc.data["events"] || []).each do |event|
+    events = doc.data["events"] || []
+    upcoming, past = events.partition { |e| e["date"] && e["date"].strftime("%Y-%m-%d") >= today_str }
+    doc.data["upcoming_events"] = upcoming.sort_by { |e| e["date"].strftime("%Y-%m-%d") }
+    doc.data["past_events"] = past.sort_by { |e| e["date"].strftime("%Y-%m-%d") }.reverse
+
+    past.each do |event|
       next unless event["date"]
-      date_str = event["date"].strftime("%Y-%m-%d")
-      next if date_str >= today_str
 
       past_events << {
         "city"    => doc.data["city"],

--- a/spec/citycamp_events_split_spec.rb
+++ b/spec/citycamp_events_split_spec.rb
@@ -1,0 +1,80 @@
+require "jekyll"
+require "timecop"
+require "tmpdir"
+require "fileutils"
+
+RSpec.describe "citycamp upcoming/past events split" do
+  Jekyll.logger.log_level = :error
+
+  def build_site(today:)
+    source = Dir.mktmpdir
+    FileUtils.mkdir_p(File.join(source, "_citycamp"))
+    FileUtils.mkdir_p(File.join(source, "_layouts"))
+    FileUtils.mkdir_p(File.join(source, "_plugins"))
+
+    File.write(File.join(source, "_layouts", "citycamp-city.html"), "---\n---\n{{ page.city }}")
+    FileUtils.cp(
+      File.join(__dir__, "..", "_plugins", "citycamp_latest_event.rb"),
+      File.join(source, "_plugins", "citycamp_latest_event.rb")
+    )
+    FileUtils.cp(
+      File.join(__dir__, "..", "_plugins", "current_date.rb"),
+      File.join(source, "_plugins", "current_date.rb")
+    )
+
+    File.write(File.join(source, "_citycamp", "testville.md"), <<~MARKDOWN)
+      ---
+      layout: citycamp-city
+      city: "Testville"
+      country: "United States"
+      latitude: 1.0
+      longitude: 1.0
+      events:
+        - name: "Old Event"
+          date: 2020-01-01
+        - name: "Today Event"
+          date: 2024-06-15
+        - name: "Future Event"
+          date: 2099-01-01
+      ---
+    MARKDOWN
+
+    config = Jekyll.configuration(
+      "source" => source,
+      "destination" => File.join(source, "_site"),
+      "collections" => { "citycamp" => { "output" => true, "permalink" => "/citycamp/:name" } }
+    )
+
+    site = Timecop.freeze(today) do
+      site = Jekyll::Site.new(config)
+      site.read
+      site.render
+      site
+    end
+
+    site.collections["citycamp"].docs.find { |doc| doc.data["city"] == "Testville" }
+  ensure
+    FileUtils.remove_entry(source) if source
+  end
+
+  it "splits events into upcoming and past relative to the current date" do
+    doc = build_site(today: Date.new(2024, 6, 20))
+
+    expect(doc.data["upcoming_events"].map { |e| e["name"] }).to eq(["Future Event"])
+    expect(doc.data["past_events"].map { |e| e["name"] }).to eq(["Today Event", "Old Event"])
+  end
+
+  it "treats an event dated today as upcoming" do
+    doc = build_site(today: Date.new(2024, 6, 15))
+
+    expect(doc.data["upcoming_events"].map { |e| e["name"] }).to eq(["Today Event", "Future Event"])
+    expect(doc.data["past_events"].map { |e| e["name"] }).to eq(["Old Event"])
+  end
+
+  it "sorts upcoming events soonest-first and past events most-recent-first" do
+    doc = build_site(today: Date.new(2019, 1, 1))
+
+    expect(doc.data["upcoming_events"].map { |e| e["name"] }).to eq(["Old Event", "Today Event", "Future Event"])
+    expect(doc.data["past_events"]).to eq([])
+  end
+end


### PR DESCRIPTION
- City pages now show separate "Upcoming events" and "Past events" sections instead of one combined "Future and past events" list, split via a Jekyll `pre_render` hook comparing each event's date against the current date.
- Adds Timecop as a test dependency and a spec that freezes the date to verify the upcoming/past split, the same-day boundary, and sort order (upcoming soonest-first, past most-recent-first).